### PR TITLE
Arma 1.96 Errors

### DIFF
--- a/@epochhive/addons/epoch_SPK_ESVP/fn_initESVP_server.sqf
+++ b/@epochhive/addons/epoch_SPK_ESVP/fn_initESVP_server.sqf
@@ -1,4 +1,4 @@
-waitUntil{missionNamespace getVariable 'EPOCH_SERVER_READY'};
+waitUntil{missionNamespace getVariable  ['EPOCH_SERVER_READY',false]};
 diag_log text '(SPK-DEBUG): loading ESVP serverside addon...';
 _ESVP_server_debugMode = getText(configFile >> 'CfgESVP' >> '_debugLog') isEqualTo str(true);
 _coords = getArray(configFile >> 'CfgESVP' >> '_safezoneCoords');

--- a/mpmissions/epoch.Mapname/SPKcode/ESVP/init.sqf
+++ b/mpmissions/epoch.Mapname/SPKcode/ESVP/init.sqf
@@ -63,11 +63,11 @@
 			};
 			loadedAccessCheckESVP = true;
 			while{true}do{
-				waitUntil{if({if(cursorTarget isKindOf _x)exitWith{1}}count['Car','Air','Motorcycle','Tank','Ship'] == 0)then{uiSleep .2;false};if(({if(cursorTarget isKindOf _x)exitWith{1}}count['Car','Air','Motorcycle','Tank','Ship'] == 1) || !isESVP)then{true}};
+				waituntil {{cursorTarget isKindOf _x} count ['Car','Air','Motorcycle','Tank','Ship'] > 0 || !isESVP};
 				if(!isESVP)exitWith{loadedAccessCheckESVP = false};
 				_var = cursorTarget getVariable['vehOwners',nil];
 				if(!isNil'_var')then{if !(getPlayerUID player in _var)then{cursorTarget lock true;uiSleep .1;cursorTarget lock true;[] spawn accessCheckEject}};
-				waitUntil{if(locked cursorTarget isEqualTo 0)then[{uiSleep .2;false},{if((locked cursorTarget isEqualTo 1) || !isESVP)then{true}}]};
+				waitUntil {(locked cursorTarget isEqualTo 1) || !isESVP};
 				if(!isESVP)exitWith{loadedAccessCheckESVP = false}
 			}
 		";


### PR DESCRIPTION
As Arma updated to 1.96, they changed a few behaviours including waituntil loops. This broke ESVP with 3 errors. 2 of those spammed the client report hard while players were in the safezones and not only broke ESVP but, made quite a hit on client performance.

Thanks to @Ignatz-HeMan for the fixes